### PR TITLE
fix b-type immediate bit swizzling

### DIFF
--- a/labs/03_risc-v-cpu/rv32i.py
+++ b/labs/03_risc-v-cpu/rv32i.py
@@ -180,11 +180,11 @@ def line_to_bits(line, labels={}, address=0):
             raise LineException(
                 f"label '{label}' was not in the stored table.", )
         offset = int(labels[label]) - address
-        imm12 = BitArray(int=offset, length=12)
+        imm12 = BitArray(int=offset, length=13)
         print(
             f"Found a branch, setting BTA to offset = {offset}, imm12 = {imm12}")
         bits = imm12[0:1] + imm12[2:8] + rs2 + rs1 + funct3_codes[instruction] + \
-            imm12[7:11] + imm12[1:2] + op_codes[instruction]
+            imm12[8:12] + imm12[1:2] + op_codes[instruction]
     if instruction == 'jal':
         rd, label = args
         rd = register_to_bits(rd)

--- a/labs/03_rv32i_part2/rv32i.py
+++ b/labs/03_rv32i_part2/rv32i.py
@@ -246,8 +246,8 @@ def line_to_bits(line, labels={}, address=0):
             )
         offset = int(labels[label]) - address
         # offset = offset >> 1  # TODO(avinash) double check
-        check_imm(offset, 12)
-        imm12 = BitArray(int=offset, length=12)
+        check_imm(offset, 13)
+        imm12 = BitArray(int=offset, length=13)
         print("#" * 48)
 
         print(
@@ -262,7 +262,7 @@ def line_to_bits(line, labels={}, address=0):
             + rs2
             + rs1
             + funct3_codes[instruction]
-            + imm12[7:11]
+            + imm12[8:12]
             + imm12[1:2]
             + op_codes[instruction]
         )


### PR DESCRIPTION
`imm12[7]` was repeated twice, causing a bug. `imm12` should also be able hold 13 bits of data, because the least significant bit is always assumed to be zero.